### PR TITLE
Add public getter for isSearching

### DIFF
--- a/lib/src/flutter_search_bar_base.dart
+++ b/lib/src/flutter_search_bar_base.dart
@@ -91,6 +91,9 @@ class SearchBar {
     });
   }
 
+  /// Whether search is currently active.
+  bool get isSearching => _isSearching;
+
   /// Initializes the search bar.
   ///
   /// This adds a new route that listens for onRemove (and stops the search when that happens), and then calls [setState] to rebuild and start the search.


### PR DESCRIPTION
I need to be able to know whether or not search is active when rendering my view.

Without this I can't determine if search was cancelled when the user navigated back from the search bar's `LocalHistoryEntry` without otherwise interacting with the search bar.