### PR TITLE
Add the onClosed event to searchBar

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -40,7 +40,10 @@ class _SearchBarDemoHomeState extends State<SearchBarDemoHome> {
         inBar: false,
         buildDefaultAppBar: buildAppBar,
         setState: setState,
-        onSubmitted: onSubmitted);
+        onSubmitted: onSubmitted,
+        onClosed: () {
+          print("closed");
+        });
   }
 
   @override

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -2,7 +2,8 @@ name: example
 description: An example for the flutter_search_bar module
 
 dependencies:
-  flutter_search_bar: any
+  flutter_search_bar:
+    path: ../
   flutter:
     sdk: flutter
 

--- a/lib/src/flutter_search_bar_base.dart
+++ b/lib/src/flutter_search_bar_base.dart
@@ -28,6 +28,9 @@ class SearchBar {
   /// A void callback which takes a string as an argument, this is fired every time the search is submitted. Do what you want with the result.
   final TextFieldSubmitCallback onSubmitted;
 
+  /// A void callback which gets fired on close button press.
+  final VoidCallback onClosed;
+
   /// Since this should be inside of a State class, just pass setState to this.
   final SetStateCallback setState;
 
@@ -63,7 +66,8 @@ class SearchBar {
     this.closeOnSubmit = true,
     this.clearOnSubmit = true,
     this.showClearButton = true,
-    this.onChanged
+    this.onChanged,
+    this.onClosed
   }) {
     if (this.controller == null) {
       this.controller = new TextEditingController();
@@ -141,9 +145,19 @@ class SearchBar {
     Color textColor = inBar ? Colors.white70 : Colors.black54;
 
     return new AppBar(
-      leading: new BackButton(
-          color: buttonColor
-      ),
+      leading: IconButton(
+          icon: const BackButtonIcon(),
+          color: buttonColor,
+          tooltip: MaterialLocalizations
+              .of(context)
+              .backButtonTooltip,
+          onPressed: () {
+            if (onClosed != null) {
+              onClosed();
+            }
+            controller.clear();
+            Navigator.maybePop(context);
+          }),
       backgroundColor: barColor,
       title: new Directionality(
           textDirection: Directionality.of(context),


### PR DESCRIPTION
This PR is related to adding the `onClosed` callback method to `searchBar` and this is related to [issue](https://github.com/ArcticZeroo/flutter-search-bar/issues/23)