### PR TITLE
Added missing repository url

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,6 +2,7 @@ name: flutter_search_bar
 description: A (mostly) automatic search bar inside an AppBar for flutter
 version: 2.1.0
 homepage: https://frozor.io
+repository: https://github.com/ArcticZeroo/flutter-search-bar
 author: Spencer <spencer@frozor.io>
 
 environment:


### PR DESCRIPTION
In this package's [pub page](https://pub.dev/packages/flutter_search_bar), the homepage is set to `https://frozor.io`, and that's perfectly ok.

Though, there is no direct link to this GitHub repo, which means that the visibility of the code is very bad.

This PR is a simple fix for this problem.